### PR TITLE
fix small bug in setup.sh

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -34,7 +34,7 @@ ask() {
 }
 
 dir=`pwd`
-if [ ! -e "${dir}/${0}" ]; then
+if [ ! -e "${dir}/$(basename $0)" ]; then
   echo "Script not called from within repository directory. Aborting."
   exit 2
 fi


### PR DESCRIPTION
`${dir}/${0}` always exists, because `$0` ("script name") includes the path _to_ the script. I think you meant `$(basename 0}` to ensure you are in the same directory? I could be wrong, it just looks that way.